### PR TITLE
Fix negative margin handling

### DIFF
--- a/src/ass_dialogue.cpp
+++ b/src/ass_dialogue.cpp
@@ -118,7 +118,7 @@ void AssDialogue::Parse(std::string const& raw) {
 	Style = tkn.next_str_trim();
 	Actor = tkn.next_str_trim();
 	for (int& margin : Margin)
-		margin = mid(0, boost::lexical_cast<int>(tkn.next_str()), 9999);
+		margin = mid(-9999, boost::lexical_cast<int>(tkn.next_str()), 99999);
 	Effect = tkn.next_str_trim();
 
 	std::string text{tkn.next_tok().begin(), str.end()};

--- a/src/ass_style.cpp
+++ b/src/ass_style.cpp
@@ -158,9 +158,9 @@ AssStyle::AssStyle(std::string const& str, int version) {
 	if (version == 0)
 		alignment = SsaToAss(alignment);
 
-	Margin[0] = mid(0, p.next_int(), 9999);
-	Margin[1] = mid(0, p.next_int(), 9999);
-	Margin[2] = mid(0, p.next_int(), 9999);
+	Margin[0] = mid(-9999, p.next_int(), 99999);
+	Margin[1] = mid(-9999, p.next_int(), 99999);
+	Margin[2] = mid(-9999, p.next_int(), 99999);
 
 	// Skip alpha level
 	if (version == 0)

--- a/src/dialog_resample.cpp
+++ b/src/dialog_resample.cpp
@@ -112,7 +112,7 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 
 	// Create all controls and set validators
 	for (size_t i = 0; i < 4; ++i) {
-		margin_ctrl[i] = new wxSpinCtrl(&d, -1, "0", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, -9999, 9999, 0);
+		margin_ctrl[i] = new wxSpinCtrl(&d, -1, "0", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, -9999, 99999, 0);
 		margin_ctrl[i]->SetValidator(wxGenericValidator(&settings.margin[i]));
 	}
 

--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -200,7 +200,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	for (int i = 0; i < 3; i++) {
 		margin[i] = new wxSpinCtrl(this, -1, std::to_wstring(style->Margin[i]),
 			wxDefaultPosition, wxDefaultSize,
-			wxSP_ARROW_KEYS, 0, 9999, style->Margin[i]);
+			wxSP_ARROW_KEYS, -9999, 99999, style->Margin[i]);
 #if wxCHECK_VERSION(3, 1, 3)
 		margin[i]->SetInitialSize(margin[i]->GetSizeFromText(wxS("0000")));
 #else

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -271,18 +271,18 @@ SubsEditBox::~SubsEditBox() {
 }
 
 wxTextCtrl *SubsEditBox::MakeMarginCtrl(wxString const& tooltip, int margin, wxString const& commit_msg) {
-	wxTextCtrl *ctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_CENTRE | wxTE_PROCESS_ENTER, IntValidator());
+	wxTextCtrl *ctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_CENTRE | wxTE_PROCESS_ENTER, IntValidator(0, true));
 #if wxCHECK_VERSION(3, 1, 3)
-	ctrl->SetInitialSize(ctrl->GetSizeFromText(wxS("0000")));
+	ctrl->SetInitialSize(ctrl->GetSizeFromText(wxS("00000")));
 #else
-	ctrl->SetInitialSize(ctrl->GetSizeFromTextSize(GetTextExtent(wxS("0000"))));
+	ctrl->SetInitialSize(ctrl->GetSizeFromTextSize(GetTextExtent(wxS("00000"))));
 #endif
-	ctrl->SetMaxLength(4);
+	ctrl->SetMaxLength(5);
 	ctrl->SetToolTip(tooltip);
 	middle_left_sizer->Add(ctrl, wxSizerFlags().Expand());
 
 	Bind(wxEVT_TEXT, [=](wxCommandEvent&) {
-		int value = agi::util::mid(0, atoi(ctrl->GetValue().utf8_str()), 9999);
+		int value = agi::util::mid(-9999, atoi(ctrl->GetValue().utf8_str()), 99999);
 		SetSelectedRows([&](AssDialogue *d) { d->Margin[margin] = value; },
 			commit_msg, AssFile::COMMIT_DIAG_META);
 	}, ctrl->GetId());


### PR DESCRIPTION
See TypesettingTools/Aegisub#104. 

Previously, margins were clamped to 0..9999, but negative margins are well supported by most renderers. In addition, previously lua automations automations were able to produce these negative margin values, and they would be saved correctly. However, re-opening the file would clamp the values, and they could not be edited in the edit box.

This changes the clamping to be -9999..99999, and allows entering (and editing) negative values in all relevant fields. In addition, this makes the subtitle edit box margin fields take 5 characters instead of 4 to accommodate negative numbers up to 9999 (also the reason for raising the upper bound.