### PR TITLE
fix include path for ass.h

### DIFF
--- a/src/subtitles_provider_libass.cpp
+++ b/src/subtitles_provider_libass.cpp
@@ -59,7 +59,7 @@
 #include <wx/thread.h>
 
 extern "C" {
-#include <ass.h>
+#include <ass/ass.h>
 }
 
 namespace {


### PR DESCRIPTION
`libass/libass/ass.h` is the source location
but `ass.h` is installed as `include/ass/ass.h`

for example, [mpv](https://github.com/mpv-player/mpv/blob/6265724f3331e3dee8d9ec2b6639def5004a5fa2/sub/ass_mp.h#L26) has

```c
#include <ass/ass.h>
```

todo

* remove libass from /vendor/ folder
* use `include/ass/ass.h` from package manger (apt, nix, conan ...)