### PR TITLE
Add automation function to get pixel value

### DIFF
--- a/src/video_controller.cpp
+++ b/src/video_controller.cpp
@@ -40,6 +40,7 @@
 #include "time_range.h"
 #include "async_video_provider.h"
 #include "utils.h"
+#include "video_frame.h"
 
 #include <libaegisub/ass/time.h>
 
@@ -220,6 +221,11 @@ int VideoController::TimeAtFrame(int frame, agi::vfr::Time type) const {
 
 int VideoController::FrameAtTime(int time, agi::vfr::Time type) const {
 	return context->project->Timecodes().FrameAtTime(time, type);
+}
+
+std::shared_ptr<VideoFrame> VideoController::GetFrame(int frame) const {
+	// timestamp is only used for subtitle fetching
+	return provider->GetFrame(frame, 0.0, true);
 }
 
 void VideoController::OnVideoError(VideoProviderErrorEvent const& err) {

--- a/src/video_controller.h
+++ b/src/video_controller.h
@@ -39,6 +39,7 @@ class AssDialogue;
 class AsyncVideoProvider;
 struct SubtitlesProviderErrorEvent;
 struct VideoProviderErrorEvent;
+struct VideoFrame;
 
 namespace agi {
 	struct Context;
@@ -159,4 +160,5 @@ public:
 
 	int TimeAtFrame(int frame, agi::vfr::Time type = agi::vfr::EXACT) const;
 	int FrameAtTime(int time, agi::vfr::Time type = agi::vfr::EXACT) const;
+	std::shared_ptr<VideoFrame> GetFrame(int frame) const;
 };


### PR DESCRIPTION
Not sure if you still accept PRs, but this patch adds `aegisubdc.get_pixel_value(int frameNumber, int x, int y)` to the lua automation api. Return value is a string in AssOverrideFormat e.g. `&H030201&`.

I added the function to a new `aegisubdc` namespace instead of `aegisub` to make sure that people know it wont work in other builds. Alternatively the function could be added to the `aegisub` namespace in hopes that it will at some point be added to the main repo.