### PR TITLE
Add automation function to get frame

### DIFF
--- a/automation/v4-docs/get-frame.txt
+++ b/automation/v4-docs/get-frame.txt
@@ -1,0 +1,69 @@
+Video Frame functions in Automation 4
+
+This file describes the interface used for reading frames from loaded videos.
+
+---
+
+Get a specific frame from the currently loaded video on which multiple other
+functions are defined.
+
+function aegisub.get_frame(frame_number, withSubtitles)
+
+@frame_number (number)
+  Number of frame to retrieve.
+
+@withSubtitles (boolean)
+  Optional. Whether to load with subtitles drawn on to the frame.
+
+Returns: frame (userdata)
+  The frame object defines multiple other functions. See below.
+
+---
+
+Get width of frame object.
+
+function frame:width()
+
+Returns: number
+  Width in pixels.
+
+---
+
+Get height of frame object.
+
+function frame:height()
+
+Returns: number
+  Height in pixels.
+
+---
+
+Get RGB pixel value at a certain position of frame object.
+
+function frame:frame:getPixel(x, y)
+
+@x (number)
+  Pixel to retrieve on the x-axis
+
+@y (number)
+  Pixel to retrieve on the y-axis
+
+Returns: number
+  Integer value representing the RGB pixel value.
+
+---
+
+Get ASS formated pixel value at a certain position of frame object.
+
+function frame:getPixelFormatted(x, y)
+
+@x (number)
+  Pixel to retrieve on the x-axis
+
+@y (number)
+  Pixel to retrieve on the y-axis
+
+Returns: string
+  String in ASS format representing the pixel value. e.g. "&H0073FF&"
+
+---

--- a/src/video_controller.cpp
+++ b/src/video_controller.cpp
@@ -40,6 +40,7 @@
 #include "time_range.h"
 #include "async_video_provider.h"
 #include "utils.h"
+#include "video_frame.h"
 
 #include <libaegisub/ass/time.h>
 
@@ -220,6 +221,11 @@ int VideoController::TimeAtFrame(int frame, agi::vfr::Time type) const {
 
 int VideoController::FrameAtTime(int time, agi::vfr::Time type) const {
 	return context->project->Timecodes().FrameAtTime(time, type);
+}
+
+std::shared_ptr<VideoFrame> VideoController::GetFrame(int frame, bool raw) const {
+	double timestamp = TimeAtFrame(frame, agi::vfr::EXACT);
+	return provider->GetFrame(frame, timestamp, raw);
 }
 
 void VideoController::OnVideoError(VideoProviderErrorEvent const& err) {

--- a/src/video_controller.h
+++ b/src/video_controller.h
@@ -39,6 +39,7 @@ class AssDialogue;
 class AsyncVideoProvider;
 struct SubtitlesProviderErrorEvent;
 struct VideoProviderErrorEvent;
+struct VideoFrame;
 
 namespace agi {
 	struct Context;
@@ -159,4 +160,5 @@ public:
 
 	int TimeAtFrame(int frame, agi::vfr::Time type = agi::vfr::EXACT) const;
 	int FrameAtTime(int time, agi::vfr::Time type = agi::vfr::EXACT) const;
+	std::shared_ptr<VideoFrame> GetFrame(int frame, bool raw) const;
 };


### PR DESCRIPTION
Adds new functionality to the Lua automation API that exposes a video frame.
Here is a lua code snippet showing how this currently works:
```lua
frame = aegisub.get_frame(current_frame) -- current_frame is integer
frameWithSubtitles = aegisub.get_frame(current_frame, true) -- subtitles are baked in to the video if needed

width = frame:width() -- The colon is important here as frame:width()  = frame.width(frame) 
print("Frame width: " .. width) -- Frame width: 1920
height = frame:height()
print("Frame height: " .. height) -- Frame height: 1080

pixelString = frame:getPixelFormatted(x, y)
print("Pixel String: " .. pixelString) -- Pixel String: &H0073FF&

pixelInt = frame:getPixel(x, y)
print("Pixel Raw: #" .. string.format("%x", pixelInt)) -- Pixel Raw: #ff7300
```

In general having people test this before merging would be great.